### PR TITLE
Make MySelectedItemsBindingBehavior attachable to multiple DependencyObjects

### DIFF
--- a/GridView/BindingSelectedItemsFromViewModel/MySelectedItemsBindingBehavior.cs
+++ b/GridView/BindingSelectedItemsFromViewModel/MySelectedItemsBindingBehavior.cs
@@ -3,6 +3,7 @@ using System.Windows;
 using Telerik.Windows.Controls;
 using System.Collections.Specialized;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Windows.Data;
 
 namespace BindingSelectedItemsFromViewModel

--- a/GridView/BindingSelectedItemsFromViewModel/MySelectedItemsBindingBehavior.cs
+++ b/GridView/BindingSelectedItemsFromViewModel/MySelectedItemsBindingBehavior.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows;
 using Telerik.Windows.Controls;
 using System.Collections.Specialized;
@@ -11,8 +11,8 @@ namespace BindingSelectedItemsFromViewModel
     {
         private readonly RadGridView grid = null;
         private readonly INotifyCollectionChanged selectedItems = null;
-        private Boolean isSubscribedToEvents = false;
-        private static Boolean isAttached = false;
+        private bool isSubscribedToEvents = false;
+        private static ConcurrentDictionary<DependencyObject, bool> isAttachedDictionary = new ConcurrentDictionary<DependencyObject, bool>();
 
 
         public static readonly DependencyProperty SelectedItemsProperty
@@ -34,11 +34,11 @@ namespace BindingSelectedItemsFromViewModel
             RadGridView grid = dependencyObject as RadGridView;
             INotifyCollectionChanged selectedItems = e.NewValue as INotifyCollectionChanged;
 
-            if (grid != null && selectedItems != null && !isAttached)
+            if (grid != null && selectedItems != null && (!isAttachedDictionary.ContainsKey(dependencyObject) || !isAttachedDictionary[dependencyObject]))
             {
                 MySelectedItemsBindingBehavior behavior = new MySelectedItemsBindingBehavior(grid, selectedItems);
                 behavior.Attach();
-                isAttached = true;
+                isAttachedDictionary[dependencyObject] = true;
             }
         }
 


### PR DESCRIPTION
As discussed in the thread http://www.telerik.com/forums/selecteditemsbehavior-fixes-for-crashes-changing-datacontext and suggested by Svenn and Amine, it should be possible to attach the Behavior tu multiple DependencyObjects.