### PR TITLE
Fixed implicit telerik:RadTreeViewItem style by basing it on a theme'…

### DIFF
--- a/TreeView/DragDropTreeViewToControls/MainWindow.xaml
+++ b/TreeView/DragDropTreeViewToControls/MainWindow.xaml
@@ -51,7 +51,7 @@
                 <Setter Property="telerik:DragDropManager.AllowCapturedDrag" Value="True" />
             </Style>
 
-            <Style TargetType="telerik:RadTreeViewItem">
+            <Style TargetType="telerik:RadTreeViewItem" BasedOn="{StaticResource {x:Type telerik:RadTreeViewItem}}">
                 <Setter Property="IsExpanded" Value="True" />
             </Style>
         </Grid.Resources>


### PR DESCRIPTION
…s default style. (The example previously was broken as it did not display anything for the tree.)